### PR TITLE
Make "Max Array Value" more "idiomatic".

### DIFF
--- a/chapters/arrays/max-array-value.md
+++ b/chapters/arrays/max-array-value.md
@@ -9,18 +9,20 @@ You need to find the largest value contained in an array.
 
 ## Solution
 
-In ECMAScript 5, you can use `Array#reduce`. For compatibility with older javascripts, use Math.max.apply:
+You can use Math.max() JavaScript method along with splats.
 
 {% highlight coffeescript %}
-# ECMAScript 5
-[12,32,11,67,1,3].reduce (a,b) -> Math.max a, b
+Math.max [12, 32, 11, 67, 1, 3]...
 # => 67
+{% endhighlight %}
 
-# Pre-ES5
-Math.max.apply(null, [12,32,11,67,1,3])
+Alternatively, it's possible to use ES5 `reduce` method.
+
+{% highlight coffeescript %}
+[12, 32, 11, 67, 1, 3].reduce (a,b) -> Math.max a, b
 # => 67
 {% endhighlight %}
 
 ## Discussion
 
-`Math.max` compares two numbers and returns the larger of the two; the rest of this recipe (both versions) is just iterating over the array to find the largest one.
+`Math.max` compares every argument and returns the largest number from arguments. The ellipsis (`...`) converts every array value into argument which is given to the function. You can also use it with other functions which take variable ammount of arguments, such as `console.log`.


### PR DESCRIPTION
Currently, "Max Array Value" doesn't really use CoffeeScript idioms. It uses `.apply` when splats could have been used instead.
