### PR TITLE
Update chapters/arrays/zip-function.md

### DIFF
--- a/chapters/arrays/zip-function.md
+++ b/chapters/arrays/zip-function.md
@@ -15,7 +15,7 @@ Use the following CoffeeScript code:
 # Usage: zip(arr1, arr2, arr3, ...)
 zip = () ->
   lengthArray = (arr.length for arr in arguments)
-  length = Math.max(lengthArray...)
+  length = Math.min(lengthArray...)
   for i in [0...length]
     arr[i] for arr in arguments
 


### PR DESCRIPTION
Using the max length of the list arguments does not match python
specification of zip. I guess that's ok if we make the behavior in this
boundary case clear.
