### PR TITLE
Corrected a solution for getting last day of the month

### DIFF
--- a/chapters/dates_and_times/finding-last-day-of-the-month.md
+++ b/chapters/dates_and_times/finding-last-day-of-the-month.md
@@ -13,9 +13,9 @@ Use JavaScript's Date underflow to find the -1th day of the following month:
 
 {% highlight coffeescript %}
 now = new Date
-lastDayOfTheMonth = new Date(1900+now.getYear(), now.getMonth()+1, -1)
+lastDayOfTheMonth = new Date(1900+now.getYear(), now.getMonth()+1, 0)
 {% endhighlight %}
 
 ## Discussion
 
-JavaScript's Date constructor cheerfully handles overflow and underflow conditions, which makes date math very easy. Given this ease of manipulation, it doesn't make sense to worry about how many days are in a given month; just nudge the math around. In December, the solution above will actually ask for the -1th day of the 13th month of the current year, which works out to the -1th day of January of NEXT year, which works out to the 31st day of December of the current year.
+JavaScript's Date constructor cheerfully handles overflow and underflow conditions, which makes date math very easy. Given this ease of manipulation, it doesn't make sense to worry about how many days are in a given month; just nudge the math around. In December, the solution above will actually ask for the 0th day of the 13th month of the current year, which works out to the day before the 1st day of January of NEXT year, which works out to the 31st day of December of the current year.


### PR DESCRIPTION
Have tested this in Chrome 23, Firefox 17 and Opera 12.

This SO page also relates http://stackoverflow.com/questions/222309/calculate-last-day-of-month-in-javascript

The cookbook is a fantastic resource, btw!
