### PR TITLE
Chaining recipe is sharing the array object

### DIFF
--- a/chapters/classes_and_objects/chaining.md
+++ b/chapters/classes_and_objects/chaining.md
@@ -13,10 +13,11 @@ Return the `this` (i.e. `@`) object after every chained method.
 
 {% highlight coffeescript %}
 class CoffeeCup
-	properties:
-		strength: 'medium'
-		cream: false
-		sugar: false
+	constructor:  ->
+		@properties=
+			strength: 'medium'
+			cream: false
+			sugar: false
 	strength: (newStrength) ->
 		@properties.strength = newStrength
 		@
@@ -57,13 +58,13 @@ addChainedAttributeAccessor = (obj, propertyAttr, attr) ->
 			obj
 
 class TeaCup
-	properties:
-		size: 'medium'
-		type: 'black'
-		sugar: false
-		cream: false
-
-addChainedAttributeAccessor(TeaCup.prototype, 'properties', attr) for attr of TeaCup.prototype.properties
+	constructor:  ->
+		@properties=
+			size: 'medium'
+			type: 'black'
+			sugar: false
+			cream: false
+		addChainedAttributeAccessor(this, 'properties', attr) for attr of @properties
 
 earlgrey = new TeaCup().size('small').type('Earl Grey').sugar('false')
 


### PR DESCRIPTION
The recipe "chapters/classes_and_objects/chaining.md" is not working as expected.

The properties list is shared with all instances of the class. So changes to one instance will change the setting for all instances.

See here: http://stackoverflow.com/questions/8355371/coffeescript-class-members
