### PR TITLE
lesson on class variables is incorrect.

### DIFF
--- a/chapters/classes_and_objects/class-variables.md
+++ b/chapters/classes_and_objects/class-variables.md
@@ -15,21 +15,29 @@ class Zoo
   MAX_ZOOKEEPERS: 3
   
   helpfulInfo: =>
-    "Zoos may contain a maximum of #{@constructor.MAX_ANIMALS} animals"
+    "Zoos may contain a maximum of #{@constructor.MAX_ANIMALS} animals and #{@MAX_ZOOKEEPERS} zoo keepers."
 
 Zoo.MAX_ANIMALS
 # => 50
 
 Zoo.MAX_ZOOKEEPERS
-# => undefined (it is an instance variable)
+# => undefined (it is a prototype member)
+
+Zoo::MAX_ZOOKEEPERS
+# => 3
 
 zoo = new Zoo
 zoo.MAX_ZOOKEEPERS
 # => 3
 zoo.helpfulInfo()
-# => "Zoos may contain a maximum of 50 animals"
+# => "Zoos may contain a maximum of 50 animals and 3 zoo keepers."
+
+zoo.MAX_ZOOKEEPERS = "smelly"
+zoo.MAX_ANIMALS = "seventeen"
+zoo.helpfulInfo()
+# => "Zoos may contain a maximum of 50 animals and smelly zoo keepers."
 {% endhighlight %}
 
 ## Discussion
 
-Coffeescript will store these values on the object itself rather than on the object prototype (and thus on individual object instances), which conserves memory and gives a central location to store class-level values.
+Coffeescript will store these values on the class itself rather than on the prototype it defines.  These are useful for defining variables on classes which can't be overrided by instance attribute variables.


### PR DESCRIPTION
putting attributes on the prototype does not use more memory than putting it on the constructor function.
