### PR TITLE
Math.max.apply text is confusing and non-idiomatic code suggested

### DIFF
--- a/chapters/arrays/max-array-value.md
+++ b/chapters/arrays/max-array-value.md
@@ -16,15 +16,11 @@ Math.max [12, 32, 11, 67, 1, 3]...
 # => 67
 {% endhighlight %}
 
-Alternatively, it's possible to use ES5 `reduce` method. For backward compatibility with older JavaScript implementations, use Math.max.apply:
+Alternatively, it's possible to use ES5 `reduce` method. For backward compatibility with older JavaScript implementations, use the above.
 
 {% highlight coffeescript %}
 # ECMAScript 5
 [12,32,11,67,1,3].reduce (a,b) -> Math.max a, b
-# => 67
-
-# Pre-ES5
-Math.max.apply(null, [12,32,11,67,1,3])
 # => 67
 {% endhighlight %}
 


### PR DESCRIPTION
This is a proposed change to [arrays/max-array-value](http://coffeescriptcookbook.com/chapters/arrays/max-array-value).

> For backward compatibility with older JavaScript implementations, use Math.max.apply:
> ...
> 
> ``` coffeescript
> # Pre-ES5
> Math.max.apply(null, [12,32,11,67,1,3])
> # => 67
> ```

This is confusing, because the reader may not know that splats, in this context, compile into an `apply` call.

CoffeeScript:

``` coffeescript
Math.max [12, 32, 11, 67, 1, 3]...
```

Compiles to:

``` javascript
Math.max.apply(Math, [12, 32, 11, 67, 1, 3]);
```

It's not idiomatic to recommend using apply in this (or arguably any) context with CoffeeScript.
