### PR TITLE
r.randi is undefined, should be r.rand

### DIFF
--- a/chapters/math/generating-predictable-random-numbers.md
+++ b/chapters/math/generating-predictable-random-numbers.md
@@ -62,4 +62,4 @@ Avoid the temptation to modulus the output of this generator. If you need an int
 r.randn() % 2
 {% endhighlight %}
 
-because you will most definitely not get random digits. Use `r.randi(2)` instead.
+because you will most definitely not get random digits. Use `r.rand(2)` instead.


### PR DESCRIPTION
It looks like a typo.  Our class has no method `r.randi`.  I'm assuming the footnote is wrong, rather than the code.

The code being wrong is also a possibility (considering `rand` would be the exception to `randf`, `randn`, and `rand2`), but it could point to being the primary function of the class, and the others to be for less frequent usage.
