### PR TITLE
Bring CoffeeScript idiom to conditional statement.

### DIFF
--- a/chapters/ajax/ajax_request_without_jquery.md
+++ b/chapters/ajax/ajax_request_without_jquery.md
@@ -47,7 +47,8 @@ loadDataFromServer = ->
 
   req.addEventListener 'readystatechange', ->
     if req.readyState is 4                        # ReadyState Compelte
-      if req.status in [200, 304]   # Success result codes
+      successResultCodes = [200, 304]
+      if req.status in successResultCodes
         data = eval '(' + req.responseText + ')'
         console.log 'data message: ', data.message
       else


### PR DESCRIPTION
An advantage of CoffeeScript compared to JavaScript is its ability to
check for array membership with the `in` keyword.
A feature it borrowed from Python.

I thought it could be a good idea to use it whenever possible, as it draws a clear difference between the 2 languages, showcasing a convenient CoffeeScript feature.
