### PR TITLE
Automatically update “last updated” date

### DIFF
--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -55,7 +55,7 @@ chapters:
       <section class="sidebar-block block-short">
         <nav class="navigation pages-nav home-nav">
           <h6><a class="nav-link" href="/"><span class="entypo">&oacute;</span>CoffeeScript Cookbook</a></h6>
-          <small class="thin dimmed">(last updated 28 August, 2012)</small>
+          <small class="thin dimmed">(last updated {{ site.time | date: "%d %B, %Y" }})</small>
         </nav>
       </section>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,7 +52,7 @@ chapters:
       <section class="sidebar-block block-short">
         <nav class="navigation pages-nav home-nav">
           <h6><a class="nav-link" href="/"><span class="entypo">&oacute;</span>CoffeeScript Cookbook</a></h6>
-          <small class="thin dimmed">(last updated 28 August, 2012)</small>
+          <small class="thin dimmed">(last updated {{ site.time | date: "%d %B, %Y" }})</small>
         </nav>
       </section>
 

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -54,7 +54,7 @@ chapters:
       <section class="sidebar-block block-short">
         <nav class="navigation pages-nav home-nav">
           <h6><a class="nav-link" href="/"><span class="entypo">&oacute;</span>CoffeeScript Cookbook</a></h6>
-          <small class="thin dimmed">(last updated 28 August, 2012)</small>
+          <small class="thin dimmed">(last updated {{ site.time | date: "%d %B, %Y" }})</small>
         </nav>
       </section>
 


### PR DESCRIPTION
I noticed that the “last updated” date was fixed to 28 August, 2012 and hasn’t been updated since. I replaced the date with Jekyll’s `site.time` variable so that it is automatically updated when building the site.

Just for clarification: I used `site.time` instead of `'now'` as `'now'` [doesn’t work with Ruby 1.9.3 and Liquid 2.5.1](https://github.com/Shopify/liquid/pull/117). It has been fixed with Liquid 2.5.2 but `github-pages` still uses 2.5.1 so I went with `site.time`.
