### PR TITLE
Correct unique for empty arrays

### DIFF
--- a/chapters/arrays/removing-duplicate-elements-from-arrays.md
+++ b/chapters/arrays/removing-duplicate-elements-from-arrays.md
@@ -13,7 +13,7 @@ You want to remove duplicate elements from an array.
 Array::unique = ->
   output = {}
   output[@[key]] = @[key] for key in [0...@length]
-  value for key, value of output
+  value for own key, value of output
 
 [1,1,2,2,2,3,4,5,6,6,6,"a","a","b","d","b","c"].unique()
 # => [ 1, 2, 3, 4, 5, 6, 'a', 'b', 'd', 'c' ]


### PR DESCRIPTION
As defined here: http://coffeescriptcookbook.com/chapters/arrays/removing-duplicate-elements-from-arrays

```
Array::unique = ->
  output = {}
  output[@[key]] = @[key] for key in [0...@length]
  value for key, value of output
```

[].unique() evaluates to [null] in the latest version of Chrome.

This can be fixed by using the 'own' keyword to only iterate over output's own properties. 

```
Array::unique = ->
  output = {}
  output[@[key]] = @[key] for key in [0...@length]
  value for own key, value of output
```

[].unique() evaluates to [] in the latest version of Chrome.

I'm not sure why null is a property of the empty array, but javascript can be weird like that.

An alternative fix would be to just return an empty array if @length == 0
