### PR TITLE
Set the default write concern on mongo.Db client

### DIFF
--- a/chapters/databases/mongodb.md
+++ b/chapters/databases/mongodb.md
@@ -23,7 +23,7 @@ mongo = require 'mongodb'
 
 server = new mongo.Server "127.0.0.1", 27017, {}
 
-client = new mongo.Db 'test', server
+client = new mongo.Db 'test', server, {w:1}
 
 # save() updates existing records or inserts new ones as needed
 exampleSave = (dbErr, collection) ->
@@ -43,7 +43,7 @@ mongo = require 'mongodb'
 
 server = new mongo.Server "127.0.0.1", 27017, {}
 
-client = new mongo.Db 'test', server
+client = new mongo.Db 'test', server, {w:1}
 
 exampleFind = (dbErr, collection) ->
 	console.log "Unable to access database: #{dbErr}" if dbErr


### PR DESCRIPTION
If the default write concern isn't set, mongo shows the warning message "Please ensure that you set the default write concern for the database..."
