### PR TITLE
Fix class-internal reference to class attribute

### DIFF
--- a/chapters/classes_and_objects/class-methods-and-instance-methods.md
+++ b/chapters/classes_and_objects/class-methods-and-instance-methods.md
@@ -20,7 +20,7 @@ class Songs
     @_titles
 
   constructor: (@artist, @title) ->
-    Songs._titles++
+    @constructor._titles++     # Refers to <Classname>._titles, in this case Songs.titles
 
 Songs.get_count()
 # => 0


### PR DESCRIPTION
DRY principle applied by removing the reference to the explicit classname within a class itself
