### PR TITLE
fixed broken shuffle for arrays of length 1 or 0

### DIFF
--- a/chapters/arrays/shuffling-array-elements.md
+++ b/chapters/arrays/shuffling-array-elements.md
@@ -18,12 +18,13 @@ the algorithm.
 
 {% highlight coffeescript %}
 shuffle = (a) ->
-  # From the end of the list to the beginning, pick element `i`.
-  for i in [a.length-1..1]
-    # Choose random element `j` to the front of `i` to swap with.
-    j = Math.floor Math.random() * (i + 1)
-    # Swap `j` with `i`, using destructured assignment
-    [a[i], a[j]] = [a[j], a[i]]
+  if a.length >= 2
+    # From the end of the list to the beginning, pick element `i`.
+    for i in [a.length-1..1]
+      # Choose random element `j` to the front of `i` to swap with.
+      j = Math.floor Math.random() * (i + 1)
+      # Swap `j` with `i`, using destructured assignment
+      [a[i], a[j]] = [a[j], a[i]]
   # Return the shuffled array.
   a
 


### PR DESCRIPTION
Coffeescript's range evaluator (in this case [a.length-1..1]) produces inappropriate results for Fisher-Yates when the array is length 1 or 0. The unfixed shuffle pushes undefined values onto the the array. A length check is necessary to continue with this style.
