### PR TITLE
Fixed a minor typo in the chaining page.

### DIFF
--- a/authors.md
+++ b/authors.md
@@ -34,6 +34,7 @@ The following people are totally rad and awesome because they have contributed r
 * Mike Moore *mike@blowmage.com*
 * Peter Hellberg *peter@c7.se*
 * Jamie Gaskins *jgaskins@gmail.com*
+* Sami Pussinen *me@samipussinen.com*
 * ...You! What are you waiting for? Check out the [contributing]({{ site.baseurl }}/contributing) section and get cracking!
 
 # Designers

--- a/chapters/classes_and_objects/chaining.md
+++ b/chapters/classes_and_objects/chaining.md
@@ -66,9 +66,9 @@ class TeaCup
 			cream: false
 		addChainedAttributeAccessor(this, 'properties', attr) for attr of @properties
 
-earlgrey = new TeaCup().size('small').type('Earl Grey').sugar('false')
+earlgrey = new TeaCup().size('small').type('Earl Grey').sugar(false)
 
-earlgrey.properties # => { size: 'small', type: 'Earl Grey', sugar: false }
+earlgrey.properties # => { size: 'small', type: 'Earl Grey', sugar: false, cream: false }
 
 earlgrey.sugar true
 


### PR DESCRIPTION
The last example had a small typo in it. The chained method had a string value of 'false', but the comment after that implied that it would return a boolean false. Also, the 'cream' property will be included in the returned object.