### PR TITLE
Update object-literal.md

### DIFF
--- a/chapters/classes_and_objects/object-literal.md
+++ b/chapters/classes_and_objects/object-literal.md
@@ -20,7 +20,7 @@ window.MY_NAMESPACE ?= {}
 This is equivalent to the following JavaScript:
 
 {% highlight javascript %}
-if(window.MY_NAMESPACE == null) {
+if(window.MY_NAMESPACE === null || window.MY_NAMESPACE === undefined) {
   window.MY_NAMESPACE = {};
 }
 {% endhighlight %}

--- a/chapters/classes_and_objects/object-literal.md
+++ b/chapters/classes_and_objects/object-literal.md
@@ -21,7 +21,7 @@ This is equivalent to the following JavaScript:
 
 {% highlight javascript %}
 if(window.MY_NAMESPACE == null) {
-  window.MY_NAMESPACE = window.MY_NAMESPACE
+  window.MY_NAMESPACE = {};
 }
 {% endhighlight %}
 

--- a/chapters/classes_and_objects/object-literal.md
+++ b/chapters/classes_and_objects/object-literal.md
@@ -20,7 +20,29 @@ window.MY_NAMESPACE ?= {}
 This is equivalent to the following JavaScript:
 
 {% highlight javascript %}
-window.MY_NAMESPACE = window.MY_NAMESPACE || {};
+if(window.MY_NAMESPACE == null) {
+  window.MY_NAMESPACE = window.MY_NAMESPACE
+}
 {% endhighlight %}
 
-Common JavaScript technique, using object literal to define a namespace. This saves us from clobbering the namespace if it already exists.
+## Problem
+
+You want to make a conditonal assignment if it does not exists or if it is falsy (empty, 0, null, false)
+
+## Solution
+
+Use the Conditional assignment operator
+
+{% highlight coffeescript %}
+window.my_variable ||= {}
+{% endhighlight %}
+
+## Discussion
+
+This is equivalent to the following JavaScript:
+
+{% highlight javascript %}
+window.my_variable = window.my_variable || {};
+{% endhighlight %}
+
+Common JavaScript technique, using conditional assignment to ensure that we have an object that is not falsy


### PR DESCRIPTION
The example was wrong. It stated that ?= is similar to JS || when the || will affect not only not defined scenario but also any falsy values (values that evaluate as false)

There are way too many differences between the 2:

1. window.var = false;
2. window.var = 0;
3. window.var = '';
4. window.var = null;

window.var ?= 'something'
console.log(window.var) ->
1. false
2. 0
3. ''
4. 'something'

window.var ||= 'something'
console.log(window.var) ->
1. 'something'
2. 'something'
3. 'something'
4. 'something'